### PR TITLE
fix mobile view codeblock overflow

### DIFF
--- a/theme/components/feature-demo/index.module.scss
+++ b/theme/components/feature-demo/index.module.scss
@@ -38,6 +38,7 @@
 .codeWrapper {
   flex: 1.2;
   min-width: 0;
+  max-width: 100%;
 }
 
 @media screen and (max-width: 768px) {


### PR DESCRIPTION
before:
<img width="494" alt="image" src="https://github.com/user-attachments/assets/2e569838-31e0-4c39-8bd4-aee28cd8ab8a" />

after:
<img width="448" alt="image" src="https://github.com/user-attachments/assets/8a8a5491-dc1c-4f2d-b120-ac42d83ffd3c" />
